### PR TITLE
chore(deps): bump Unidecode to version 1.3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ REQUIREMENTS = [
     "toml==0.10.2",
     "typing-extensions==3.10.0.0",
     "tzlocal==2.1",
-    "Unidecode==1.1.2",
+    "Unidecode>=1.3.6",
     "urllib3==1.26.2",
     "Werkzeug==0.16.1",
     "zipp==3.4.0",


### PR DESCRIPTION
beets require Unidecode 1.3.6 version  https://github.com/beetbox/beets/blob/c8ab0cfa6b5babf3b2b32a7a77a0303530e888a6/setup.py#L88